### PR TITLE
fix/validate middleware

### DIFF
--- a/src/middlewares/validate.js
+++ b/src/middlewares/validate.js
@@ -37,12 +37,12 @@ const validate = schema => async (req, res, next) => {
   if (error) {
     // cleanup files buffer if exist upon validation failing
     if (req.file) req.file.buffer = 0;
-    if (Array.isArray(req.files)) {
-      req.files.map(file => {
+    else if (Array.isArray(req.files)) {
+      req.files.forEach(file => {
         file.buffer = null;
       });
     }
-    if (typeof req.files === 'object') {
+    else if (typeof req.files === 'object') {
       Object.keys(req.files).forEach(key =>
         req.files[key].map(file => {
           file.buffer = null;

--- a/src/middlewares/validate.js
+++ b/src/middlewares/validate.js
@@ -41,10 +41,9 @@ const validate = schema => async (req, res, next) => {
       req.files.forEach(file => {
         file.buffer = null;
       });
-    }
-    else if (typeof req.files === 'object') {
+    } else if (typeof req.files === 'object') {
       Object.keys(req.files).forEach(key =>
-        req.files[key].map(file => {
+        req.files[key].forEach(file => {
           file.buffer = null;
         })
       );


### PR DESCRIPTION
multerUpload.array() method will put an array of file objects on req.files

Therefore, Array.isArray(req.files) will be true and the if block will get executed

However, in JS typeof [] === 'object', therefore the next if block will also be executed which is redundant.