### PR TITLE
fix/paginate-plugin-populate-timestamps

### DIFF
--- a/src/models/plugins/paginate.js
+++ b/src/models/plugins/paginate.js
@@ -66,7 +66,7 @@ module.exports.paginate = schema => {
         // iterating over the fields that has to be selected
         const selectFields =
           select === '*'
-            ? Object.keys(mongoose.model(populatingModelName).schema.obj)
+            ? Object.keys(mongoose.model(populatingModelName).schema.paths)
             : select.split(',').map(ele => {
                 // seperating the requested select field from its match condition
                 // e.g. i want name field but its value should match with pattern "Manish"


### PR DESCRIPTION
schema.obj returns the original object passed to mongoose.Schema constructor

we often use mongoose "timestamps" option to add createdAt and updatedAt fields to schema

In paginate plugin, when we use fieldName::*, it currently does not select createdAt and updatedAt fields since they are not on schema.obj

Solution: Use schema.paths